### PR TITLE
Add packrat for easy development and installation

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,3 @@
+#### -- Packrat Autoloader (version 0.4.8-1) -- ####
+source("packrat/init.R")
+#### -- End Packrat Autoloader -- ####

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+packrat/lib*/
+.Rhistory
+packrat/src/

--- a/README
+++ b/README
@@ -25,6 +25,11 @@ Install instruction
 	R CMD INSTALL --merge-multiarch KEADrugResponse_*.tar.gz
 	Unzip file
 
+Development
+
+  All packages should be installed automatically with packrat package manger
+	when running R in interactive mode.
+
 Usage
 
 	library(KEADrugResponse); library(affy);

--- a/packrat/init.R
+++ b/packrat/init.R
@@ -1,0 +1,217 @@
+local({
+
+  ## Helper function to get the path to the library directory for a
+  ## given packrat project.
+  getPackratLibDir <- function(projDir = NULL) {
+    path <- file.path("packrat", "lib", R.version$platform, getRversion())
+
+    if (!is.null(projDir)) {
+
+      ## Strip trailing slashes if necessary
+      projDir <- sub("/+$", "", projDir)
+
+      ## Only prepend path if different from current working dir
+      if (!identical(normalizePath(projDir), normalizePath(getwd())))
+        path <- file.path(projDir, path)
+    }
+
+    path
+  }
+
+  ## Ensure that we set the packrat library directory relative to the
+  ## project directory. Normally, this should be the working directory,
+  ## but we also use '.rs.getProjectDirectory()' if necessary (e.g. we're
+  ## rebuilding a project while within a separate directory)
+  libDir <- if (exists(".rs.getProjectDirectory"))
+    getPackratLibDir(.rs.getProjectDirectory())
+  else
+    getPackratLibDir()
+
+  ## Unload packrat in case it's loaded -- this ensures packrat _must_ be
+  ## loaded from the private library. Note that `requireNamespace` will
+  ## succeed if the package is already loaded, regardless of lib.loc!
+  if ("packrat" %in% loadedNamespaces())
+    try(unloadNamespace("packrat"), silent = TRUE)
+
+  if (suppressWarnings(requireNamespace("packrat", quietly = TRUE, lib.loc = libDir))) {
+
+    # Check 'print.banner.on.startup' -- when NA and RStudio, don't print
+    print.banner <- packrat::get_opts("print.banner.on.startup")
+    if (print.banner == "auto" && is.na(Sys.getenv("RSTUDIO", unset = NA))) {
+      print.banner <- TRUE
+    } else {
+      print.banner <- FALSE
+    }
+    return(packrat::on(print.banner = print.banner))
+  }
+
+  ## Escape hatch to allow RStudio to handle bootstrapping. This
+  ## enables RStudio to provide print output when automagically
+  ## restoring a project from a bundle on load.
+  if (!is.na(Sys.getenv("RSTUDIO", unset = NA)) &&
+      is.na(Sys.getenv("RSTUDIO_PACKRAT_BOOTSTRAP", unset = NA))) {
+    Sys.setenv("RSTUDIO_PACKRAT_BOOTSTRAP" = "1")
+    setHook("rstudio.sessionInit", function(...) {
+      # Ensure that, on sourcing 'packrat/init.R', we are
+      # within the project root directory
+      if (exists(".rs.getProjectDirectory")) {
+        owd <- getwd()
+        setwd(.rs.getProjectDirectory())
+        on.exit(setwd(owd), add = TRUE)
+      }
+      source("packrat/init.R")
+    })
+    return(invisible(NULL))
+  }
+
+  ## Bootstrapping -- only performed in interactive contexts,
+  ## or when explicitly asked for on the command line
+  if (interactive() || "--bootstrap-packrat" %in% commandArgs(TRUE)) {
+
+    message("Packrat is not installed in the local library -- ",
+            "attempting to bootstrap an installation...")
+
+    ## We need utils for the following to succeed -- there are calls to functions
+    ## in 'restore' that are contained within utils. utils gets loaded at the
+    ## end of start-up anyhow, so this should be fine
+    library("utils", character.only = TRUE)
+
+    ## Install packrat into local project library
+    packratSrcPath <- list.files(full.names = TRUE,
+                                 file.path("packrat", "src", "packrat")
+    )
+
+    ## No packrat tarballs available locally -- try some other means of installation
+    if (!length(packratSrcPath)) {
+
+      message("> No source tarball of packrat available locally")
+
+      ## There are no packrat sources available -- try using a version of
+      ## packrat installed in the user library to bootstrap
+      if (requireNamespace("packrat", quietly = TRUE) && packageVersion("packrat") >= "0.2.0.99") {
+        message("> Using user-library packrat (",
+                packageVersion("packrat"),
+                ") to bootstrap this project")
+      }
+
+      ## Couldn't find a user-local packrat -- try finding and using devtools
+      ## to install
+      else if (requireNamespace("devtools", quietly = TRUE)) {
+        message("> Attempting to use devtools::install_github to install ",
+                "a temporary version of packrat")
+        library(stats) ## for setNames
+        devtools::install_github("rstudio/packrat")
+      }
+
+      ## Try downloading packrat from CRAN if available
+      else if ("packrat" %in% rownames(available.packages())) {
+        message("> Installing packrat from CRAN")
+        install.packages("packrat")
+      }
+
+      ## Fail -- couldn't find an appropriate means of installing packrat
+      else {
+        stop("Could not automatically bootstrap packrat -- try running ",
+             "\"'install.packages('devtools'); devtools::install_github('rstudio/packrat')\"",
+             "and restarting R to bootstrap packrat.")
+      }
+
+      # Restore the project, unload the temporary packrat, and load the private packrat
+      packrat::restore(prompt = FALSE, restart = TRUE)
+
+      ## This code path only reached if we didn't restart earlier
+      unloadNamespace("packrat")
+      requireNamespace("packrat", lib.loc = libDir, quietly = TRUE)
+      return(packrat::on())
+
+    }
+
+    ## Multiple packrat tarballs available locally -- try to choose one
+    ## TODO: read lock file and infer most appropriate from there; low priority because
+    ## after bootstrapping packrat a restore should do the right thing
+    if (length(packratSrcPath) > 1) {
+      warning("Multiple versions of packrat available in the source directory;",
+              "using packrat source:\n- ", shQuote(packratSrcPath))
+      packratSrcPath <- packratSrcPath[[1]]
+    }
+
+
+    lib <- file.path("packrat", "lib", R.version$platform, getRversion())
+    if (!file.exists(lib)) {
+      dir.create(lib, recursive = TRUE)
+    }
+    lib <- normalizePath(lib, winslash = "/")
+
+    message("> Installing packrat into project private library:")
+    message("- ", shQuote(lib))
+
+    surround <- function(x, with) {
+      if (!length(x)) return(character())
+      paste0(with, x, with)
+    }
+
+    ## The following is performed because a regular install.packages call can fail
+    peq <- function(x, y) paste(x, y, sep = " = ")
+    installArgs <- c(
+      peq("pkgs", surround(packratSrcPath, with = "'")),
+      peq("lib", surround(lib, with = "'")),
+      peq("repos", "NULL"),
+      peq("type", surround("source", with = "'"))
+    )
+    installCmd <- paste(sep = "",
+                        "utils::install.packages(",
+                        paste(installArgs, collapse = ", "),
+                        ")")
+
+    fullCmd <- paste(
+      surround(file.path(R.home("bin"), "R"), with = "\""),
+      "--vanilla",
+      "--slave",
+      "-e",
+      surround(installCmd, with = "\"")
+    )
+    system(fullCmd)
+
+    ## Tag the installed packrat so we know it's managed by packrat
+    ## TODO: should this be taking information from the lockfile? this is a bit awkward
+    ## because we're taking an un-annotated packrat source tarball and simply assuming it's now
+    ## an 'installed from source' version
+
+    ## -- InstallAgent -- ##
+    installAgent <- 'InstallAgent: packrat 0.4.8-1'
+
+    ## -- InstallSource -- ##
+    installSource <- 'InstallSource: source'
+
+    packratDescPath <- file.path(lib, "packrat", "DESCRIPTION")
+    DESCRIPTION <- readLines(packratDescPath)
+    DESCRIPTION <- c(DESCRIPTION, installAgent, installSource)
+    cat(DESCRIPTION, file = packratDescPath, sep = "\n")
+
+    # Otherwise, continue on as normal
+    message("> Attaching packrat")
+    library("packrat", character.only = TRUE, lib.loc = lib)
+
+    message("> Restoring library")
+    restore(restart = FALSE)
+
+    # If the environment allows us to restart, do so with a call to restore
+    restart <- getOption("restart")
+    if (!is.null(restart)) {
+      message("> Packrat bootstrap successfully completed. ",
+              "Restarting R and entering packrat mode...")
+      return(restart())
+    }
+
+    # Callers (source-erers) can define this hidden variable to make sure we don't enter packrat mode
+    # Primarily useful for testing
+    if (!exists(".__DONT_ENTER_PACKRAT_MODE__.") && interactive()) {
+      message("> Packrat bootstrap successfully completed. Entering packrat mode...")
+      packrat::on()
+    }
+
+    Sys.unsetenv("RSTUDIO_PACKRAT_BOOTSTRAP")
+
+  }
+
+})

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -1,0 +1,57 @@
+PackratFormat: 1.4
+PackratVersion: 0.4.8.1
+RVersion: 3.4.2
+Repos: BioCsoft=https://bioconductor.org/packages/3.6/bioc,
+    BioCann=https://bioconductor.org/packages/3.6/data/annotation,
+    BioCexp=https://bioconductor.org/packages/3.6/data/experiment,
+    CRAN=https://cloud.r-project.org
+
+Package: Biobase
+Source: Bioconductor
+Version: 2.38.0
+Hash: 0244109184b2af652cc74c424943a85b
+Requires: BiocGenerics
+
+Package: BiocGenerics
+Source: Bioconductor
+Version: 0.24.0
+Hash: b0e8545b3d329a929c98672b0957fbde
+
+Package: BiocInstaller
+Source: Bioconductor
+Version: 1.28.0
+Hash: d0ba96fdc386731c75313f5bb5ba3d68
+
+Package: KEADrugResponse
+Source: source
+Version: 0.1.2
+Hash: 13de0520aecbdd951501d485696b36b6
+SourcePath: ./KEADrugResponse
+
+Package: affy
+Source: Bioconductor
+Version: 1.56.0
+Hash: 9cf03eba689120198cd0bbaa5fdcb949
+Requires: Biobase, BiocGenerics, BiocInstaller, affyio, preprocessCore,
+    zlibbioc
+
+Package: affyio
+Source: Bioconductor
+Version: 1.48.0
+Hash: 766b0bf0f8f54b4c71a747d5d16f86f3
+Requires: zlibbioc
+
+Package: packrat
+Source: CRAN
+Version: 0.4.8-1
+Hash: 6ad605ba7b4b476d84be6632393f5765
+
+Package: preprocessCore
+Source: Bioconductor
+Version: 1.40.0
+Hash: 3546e1e86a1f750802823c2f73540517
+
+Package: zlibbioc
+Source: Bioconductor
+Version: 1.24.0
+Hash: e3dc79a6c62193cca9cafd986eed4e02

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -6,6 +6,17 @@ Repos: BioCsoft=https://bioconductor.org/packages/3.6/bioc,
     BioCexp=https://bioconductor.org/packages/3.6/data/experiment,
     CRAN=https://cloud.r-project.org
 
+Package: AnnotationDbi
+Source: Bioconductor
+Version: 1.40.0
+Hash: 185bc9c8ccbed94957b7f4a622195278
+Requires: Biobase, BiocGenerics, DBI, IRanges, RSQLite, S4Vectors
+
+Package: BH
+Source: CRAN
+Version: 1.65.0-1
+Hash: 95f62be4d6916aae14a310a8b56a6475
+
 Package: Biobase
 Source: Bioconductor
 Version: 2.38.0
@@ -22,11 +33,39 @@ Source: Bioconductor
 Version: 1.28.0
 Hash: d0ba96fdc386731c75313f5bb5ba3d68
 
+Package: DBI
+Source: CRAN
+Version: 0.7
+Hash: 1ab72df487f06ad5f0de05446cdd4bd6
+
+Package: IRanges
+Source: Bioconductor
+Version: 2.12.0
+Hash: 20a52cdea49f9eb06ac17ebb163bc188
+Requires: BiocGenerics, S4Vectors
+
 Package: KEADrugResponse
 Source: source
 Version: 0.1.2
 Hash: 13de0520aecbdd951501d485696b36b6
 SourcePath: ./KEADrugResponse
+
+Package: RSQLite
+Source: CRAN
+Version: 2.0
+Hash: aa34cc0830f6223f6b1c419c31650000
+Requires: BH, DBI, Rcpp, bit64, blob, memoise, pkgconfig, plogr
+
+Package: Rcpp
+Source: CRAN
+Version: 0.12.13
+Hash: b9d8d89ff10ca2d8bfdaccdf83045ba1
+
+Package: S4Vectors
+Source: Bioconductor
+Version: 0.16.0
+Hash: 5b1afbd539d11cd088f381808566d3ee
+Requires: BiocGenerics
 
 Package: affy
 Source: Bioconductor
@@ -41,15 +80,70 @@ Version: 1.48.0
 Hash: 766b0bf0f8f54b4c71a747d5d16f86f3
 Requires: zlibbioc
 
+Package: bit
+Source: CRAN
+Version: 1.1-12
+Hash: a4cdb11cf9fd6dd38f9f40c413b81e93
+
+Package: bit64
+Source: CRAN
+Version: 0.9-7
+Hash: 4b195615d19ba49c114eb04e09e30a96
+Requires: bit
+
+Package: blob
+Source: CRAN
+Version: 1.1.0
+Hash: e29764e47f2faf0cd5b74cbcddc3fa9c
+Requires: tibble
+
+Package: digest
+Source: CRAN
+Version: 0.6.12
+Hash: e53fb8c58673df868183697e39a6a4d6
+
+Package: hgu133plus2cdf
+Source: Bioconductor
+Version: 2.18.0
+Hash: 1545b2af0acb4d038f3235f0bd38c30d
+Requires: AnnotationDbi
+
+Package: memoise
+Source: CRAN
+Version: 1.1.0
+Hash: 410fcd334bc626db100237cc1370f2e9
+Requires: digest
+
 Package: packrat
 Source: CRAN
 Version: 0.4.8-1
 Hash: 6ad605ba7b4b476d84be6632393f5765
 
+Package: pkgconfig
+Source: CRAN
+Version: 2.0.1
+Hash: 0dda4a2654a22b36a715c2b0b6fbacac
+
+Package: plogr
+Source: CRAN
+Version: 0.1-1
+Hash: fb19215402e2d9f1c7f803dcaa806fc2
+
 Package: preprocessCore
 Source: Bioconductor
 Version: 1.40.0
 Hash: 3546e1e86a1f750802823c2f73540517
+
+Package: rlang
+Source: CRAN
+Version: 0.1.2
+Hash: c17b638e3282aa222a47112d7a60bc66
+
+Package: tibble
+Source: CRAN
+Version: 1.3.4
+Hash: 3b72bdedb6c27fb216574ab9b15f2d43
+Requires: Rcpp, rlang
 
 Package: zlibbioc
 Source: Bioconductor

--- a/packrat/packrat.opts
+++ b/packrat/packrat.opts
@@ -1,0 +1,15 @@
+auto.snapshot: TRUE
+use.cache: FALSE
+print.banner.on.startup: auto
+vcs.ignore.lib: TRUE
+vcs.ignore.src: TRUE
+external.packages: 
+local.repos: .
+load.external.packages.on.startup: TRUE
+ignored.packages: roxygen2
+quiet.package.installation: TRUE
+snapshot.recommended.packages: FALSE
+snapshot.fields:
+    Imports
+    Depends
+    LinkingTo


### PR DESCRIPTION
This adds [packrat](https://rstudio.github.io/packrat/) package manager and proper local of packages for reproducible and easy installation. From now on, all packages should be installed automatically by just running "R" interactive session.

Demo: https://asciinema.org/a/390FR3NGM2u071lzCdvmaud7I